### PR TITLE
-FIX: IsOpen bool not being tracked converted to int

### DIFF
--- a/Source/AtomGameplay/Private/AtomSaveGameSubsystem.cpp
+++ b/Source/AtomGameplay/Private/AtomSaveGameSubsystem.cpp
@@ -120,7 +120,9 @@ void UAtomSaveGameSubsystem::WriteSaveGame() const
 		// Now serialize the actor itself.
 		FMemoryWriter MemoryWrite(ActorSaveData.ByteData);
 		FObjectAndNameAsStringProxyArchive Ar(MemoryWrite, true);
-		Ar.ArIsSaveGame = true;
+		Ar.ArIsSaveGame = 1;
+		Ar.ArSerializingDefaults = 1;
+		Ar.StartSerializingDefaults();
 		Actor->Serialize(Ar);
 		
 		IAtomSaveInterface::Execute_Save(Actor, CurrentSaveGame);

--- a/Source/AtomGameplay/Public/Game/AtomSlidingDoor.h
+++ b/Source/AtomGameplay/Public/Game/AtomSlidingDoor.h
@@ -38,8 +38,8 @@ public:
 	UPROPERTY(SaveGame, BlueprintReadWrite, EditAnywhere, Category="Atom|Door")
 	bool bStartsOpen;
 	
-	UPROPERTY(SaveGame, BlueprintReadOnly, VisibleAnywhere, Category="Atom|Door")
-	bool bIsOpen;
+	UPROPERTY(SaveGame, BlueprintReadWrite, EditAnywhere, Category="Atom|Door")
+	int32 IsOpen;
 
 	UPROPERTY(SaveGame, BlueprintReadOnly, VisibleAnywhere, Category="Atom|Door")
 	bool bIsInMotion;


### PR DESCRIPTION
This is a fix for atom doors not being serialized/loaded properly when set to start open